### PR TITLE
None in description rises an exception

### DIFF
--- a/milecsa/Transfer.py
+++ b/milecsa/Transfer.py
@@ -26,7 +26,10 @@ class BaseTransfer(Transaction):
         else:
             self.source = src
 
-        self.description = description
+        if description is None:
+            self.description = ""
+        else:
+            self.description = description
 
         if fee:
             self.fee = float(fee)


### PR DESCRIPTION
None in description argument rises an exception in __transfer_assets function:
TypeError: __transfer_assets(): incompatible function arguments. The following argument types are supported:
    1. (public_key: str, private_key: str, destination_public_key: str, block_id: int, transaction_id: int, asset_code: int, amount: float, fee: float, memo: str = '') -> json